### PR TITLE
feat: Add GitHub Actions workflow and fix builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -156,7 +156,7 @@ jobs:
         run: echo "$HOME/.dotnet/tools" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
       - name: Harvest files with heat
-        run: wix heat dir staging/mingw64 -o files.wxs -cg ProductComponents -dr INSTALLFOLDER
+        run: heat dir staging/mingw64 -o files.wxs -cg ProductComponents -dr INSTALLFOLDER
 
       - name: Build MSI installer
         run: wix build -o jcal-${{ env.VERSION }}.msi -ext WixToolset.UI.wixext main.wxs files.wxs

--- a/sources/pyjalali/__init__.py
+++ b/sources/pyjalali/__init__.py
@@ -23,6 +23,8 @@ __version__ = (0, 5, 0, 2)
 
 if sys.platform.startswith('win'):
     libname = 'libjalali.dll'
+elif sys.platform == 'darwin':
+    libname = 'libjalali.dylib'
 else:
     libname = 'libjalali.so'
 _libj = cdll.LoadLibrary(os.path.join(os.environ.get('LIBJALALI_DIR', ''),


### PR DESCRIPTION
This commit introduces a new GitHub Actions workflow to automate the build and release process for the project across multiple platforms (Linux, macOS, and Windows).

The workflow is configured to:
- Build for Linux, macOS, and Windows.
- Create .deb, .rpm, .tar.gz, and .msi packages.
- Upload artifacts to a GitHub Release on publish.

This commit also includes several fixes to the C source code and the workflow to address build failures on all three platforms:
- Fixed Linux dependency from `python-dev` to `python-dev-is-python3` and added `libreadline-dev`.
- Fixed macOS build by adding a missing header include in `jtime.c`, fixing an implicit function declaration, and installing the `setuptools` python package.
- Fixed Windows build by using platform-specific functions for time conversion and handling of long integers, and by correcting the WiX toolset commands.
- Implemented the missing `jalali_get_date` function to resolve a linker error.
- Corrected a typo in a function call from `jalali_create_date_from_days` to `jalali_create_days_from_date` in `jtime.c` and other files.
- Fixed the `Makefile.am` to correctly handle the python package installation.
- Fixed the python setup script to use `setuptools` instead of the deprecated `distutils`.
- Fixed the python library loading on macOS to use the correct file extension.